### PR TITLE
make it possible to GET schedules from API

### DIFF
--- a/xplenty/xplenty_api.py
+++ b/xplenty/xplenty_api.py
@@ -219,6 +219,20 @@ class Package(BaseModel):
         return "<Package '{0}'>".format(self.name)
 
 
+class Schedule(BaseModel):
+    """Xplenty Schedule."""
+
+    _strs = ['name','description', 'url', 'interval_unit', 'last_run_status', 'status']
+    _ints = ['id','owner_id', 'interval_amount', 'execution_count']
+    _floats = []
+    _dates = ['created_at','updated_at', 'start_at', 'next_run_at', 'last_run_at']
+    _dicts = ['variables', 'task']
+    _pks = ['id']
+
+    def __repr__(self):
+        return "<Schedule '{0}'>".format(self.name)
+
+
 class RequestWithMethod(urllib2.Request):
     """Workaround for using DELETE with urllib2"""
     def __init__(self, url, method, data=None, headers={},\
@@ -374,7 +388,6 @@ class XplentyClient(object):
 
         return job
 
-
     def get_account_limits(self):
 
         method_path = 'rate_limit_status'
@@ -401,6 +414,18 @@ class XplentyClient(object):
 
         return package
 
+    def get_schedules(self):
+        method_path = 'schedules'
+        url = self._join_url(method_path)
+        resp = self.get(url)
+        return [Schedule.new_from_dict(item, h=self) for item in resp]
+
+    def get_schedule(self, id):
+        method_path = 'schedules/%s' % id
+        url = self._join_url(method_path)
+        resp = self.get(url)
+        return Schedule.new_from_dict(resp, h=self)
+
     @property
     def clusters(self):
         return self.get_clusters()
@@ -416,3 +441,7 @@ class XplentyClient(object):
     @property
     def packages(self):
         return self.get_packages()
+
+    @property
+    def schedules(self):
+        return self.get_schedules()


### PR DESCRIPTION
Hi guys @motymichaely @saggineumann!

Here is a small PR to make it possible to read `Schedules` from the SDK. I've got a few remarks about what I'm getting from the API:
```python
{'created_at': datetime.datetime(2016, 1, 22, 14, 24, 41, tzinfo=tzutc()),
 'description': u'Importing Job Distributor Posts from Mongo to Redshift Shares',
 'execution_count': 39,
 'id': 492,
 'interval_amount': 1,
 'interval_unit': u'days',
 'last_run_at': datetime.datetime(2016, 3, 1, 14, 23, tzinfo=tzutc()),
 'last_run_status': u'',
 'name': u'JobDistributorPost JKR-10349',
 'next_run_at': datetime.datetime(2016, 3, 2, 14, 23, tzinfo=tzutc()),
 'owner_id': 2928,
 'start_at': datetime.datetime(2016, 1, 22, 14, 23, tzinfo=tzutc()),
 'status': u'enabled',
 'task': {u'nodes': 1,
  u'packages': [{u'package_id': u'10546',
    u'variables': {u'_BYTES_PER_REDUCER': u'209715200',
     u'_CACHED_BAG_MEMORY_PERCENT': u'0.2',
     u'_COPY_PARALLELISM': u'(int)$_CLUSTER_NODES_COUNT * 3',
     u'_COPY_TARGET_PARTITIONS': u'100',
     u'_COPY_TARGET_SIZE': u'64',
     u'_DEFAULT_PARALLELISM': u'0',
     u'_DEFAULT_TIMEZONE': u"'+00:00'",
     u'_GA_API_MAX_INPUT_SPLITS': u'10',
     u'_GA_API_REQUEST_MAX_RESULTS': u'1000',
     u'_GA_API_REQUEST_READ_TIMEOUT': u'30 * 1000',
     u'_LINE_RECORD_READER_MAX_LENGTH': u'1048576',
     u'_MAP_MAX_ATTEMPTS': u'4',
     u'_MAP_MAX_FAILURES_PERCENT': u'0',
     u'_MAP_TASK_TIMEOUT': u'600 * 1000',
     u'_MAX_COMBINED_SPLIT_SIZE': u'67108864',
     u'_PARQUET_BLOCK_SIZE': u'128 * 1024 * 1024',
     u'_PARQUET_COMPRESSION': u"'UNCOMPRESSED'",
     u'_PARQUET_PAGE_SIZE': u'1 * 1024 * 1024',
     u'_REDUCER_MAX_ATTEMPTS': u'4',
     u'_REDUCER_MAX_FAILURES_PERCENT': u'0',
     u'_SHUFFLE_INPUT_BUFFER_PERCENT': u'0.7',
     u'posted_at': u"ToString(SubtractDuration(CurrentTime(),'P2D'))"}}],
  u'terminate_on_idle': u'1',
  u'time_to_idle': 1800},
 'updated_at': datetime.datetime(2016, 3, 1, 21, 39, 40, tzinfo=tzutc()),
 'url': u'https://api.xplenty.com/work4/api/schedules/jobdistributorpost-jkr-10349'}
```
- in the `task` key, I don't see anything for the "re-use" option (available through UI)
- `terminate_on_idle` should be a boolean
- `last_run_status` is not accurate (empty)

Do you think you could merge this PR and fix those inconsistencies on your API?