### PR TITLE
Add offset and limit to get_packages()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def get_project_path(*args):
     return os.path.abspath(os.path.join(this_dir, *args))
 
 PACKAGE_NAME = 'xplenty'
-PACKAGE_VERSION = '1.0.8'
+PACKAGE_VERSION = '1.1.0'
 PACKAGE_AUTHOR = 'Xplenty'
 PACKAGE_AUTHOR_EMAIL = 'opensource@xplenty.com'
 PACKAGE_URL = 'https://github.com/xplenty/xplenty.py'

--- a/xplenty/xplenty_api.py
+++ b/xplenty/xplenty_api.py
@@ -398,8 +398,8 @@ class XplentyClient(object):
 
         return limit
 
-    def get_packages(self):
-        method_path = 'packages'
+    def get_packages(self, offset=0, limit=20):
+        method_path = 'packages?offset=%d&limit=%d' % (offset, limit)
         url = self._join_url(method_path)
         resp = self.get(url)
         packages = [Package.new_from_dict(item, h=self) for item in resp]


### PR DESCRIPTION
When an account surpasses 20 packages, the default values that were implicitly used in the API call (offset = 0, limit = 20) are no longer sufficient for the client to access all packages. Exposing these supported API parameters allows clients with more packages to access them all.

[API docs on pagination](https://github.com/xplenty/xplenty-api-doc#user-content-Collection)