### PR TITLE
Add offset and limit to get_clusters()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def get_project_path(*args):
     return os.path.abspath(os.path.join(this_dir, *args))
 
 PACKAGE_NAME = 'xplenty'
-PACKAGE_VERSION = '1.1.0'
+PACKAGE_VERSION = '1.1.1'
 PACKAGE_AUTHOR = 'Xplenty'
 PACKAGE_AUTHOR_EMAIL = 'opensource@xplenty.com'
 PACKAGE_URL = 'https://github.com/xplenty/xplenty.py'

--- a/xplenty/xplenty_api.py
+++ b/xplenty/xplenty_api.py
@@ -304,8 +304,8 @@ class XplentyClient(object):
         url = urljoin(_url , method )
         return url
 
-    def get_clusters(self):
-        method_path = 'clusters'
+    def get_clusters(self, offset=0, limit=20):
+        method_path = 'clusters?offset=%d&limit=%d' % (offset, limit)
         url = self._join_url( method_path )
         resp = self.get(url)
         clusters =  [Cluster.new_from_dict(item, h=self) for item in resp]


### PR DESCRIPTION
When an account surpasses 20 clusters, then fetching all clusters requires paginating. The API already supports these pagination parameters, so this commit just exposes them to the client.

Related to https://github.com/xplenty/xplenty.py/pull/19