### PR TITLE
Use valid model attributes in __repr__

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def get_project_path(*args):
     return os.path.abspath(os.path.join(this_dir, *args))
 
 PACKAGE_NAME = 'xplenty'
-PACKAGE_VERSION = '1.1.0'
+PACKAGE_VERSION = '1.1.2'
 PACKAGE_AUTHOR = 'Xplenty'
 PACKAGE_AUTHOR_EMAIL = 'opensource@xplenty.com'
 PACKAGE_URL = 'https://github.com/xplenty/xplenty.py'

--- a/xplenty/xplenty_api.py
+++ b/xplenty/xplenty_api.py
@@ -193,7 +193,7 @@ class Job(BaseModel):
     _pks = ['id']
 
     def __repr__(self):
-        return "<Job '{0}'>".format(self.name)
+        return "<Job '{0}'>".format(self.id)
 
 
 class AccountLimits(BaseModel):
@@ -202,7 +202,7 @@ class AccountLimits(BaseModel):
     _ints = ['limit','remaining']
 
     def __repr__(self):
-        return "<AccountLimits '{0}'>".format(self.name)
+        return "<AccountLimits '{0}'>".format(self.remaining)
 
 
 class Package(BaseModel):


### PR DESCRIPTION
All models used `self.name` in the string representation of the object, yet `Job` and `AccountLimits` don't have a `name` attribute. Thus if you tried to print one of these objects out, you'd get an error. I've updated the `__repr__` method to use the most meaningful attribute.

```python
>>> job = client.get_job(10459589)
>>> print(job)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "xplenty/xplenty_api.py", line 205, in __repr__
    return "<Job '{0}'>".format(self.name)
AttributeError: 'Job' object has no attribute 'name'
```