### PR TITLE
Add dual support for python 2 and python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def get_project_path(*args):
     return os.path.abspath(os.path.join(this_dir, *args))
 
 PACKAGE_NAME = 'xplenty'
-PACKAGE_VERSION = '1.1.2'
+PACKAGE_VERSION = '1.2.0'
 PACKAGE_AUTHOR = 'Xplenty'
 PACKAGE_AUTHOR_EMAIL = 'opensource@xplenty.com'
 PACKAGE_URL = 'https://github.com/xplenty/xplenty.py'

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,8 @@ PACKAGE_LICENSE = 'MIT'
 PACKAGE_DESCRIPTION = 'Xplenty API Python SDK'
 PACKAGE_INCLUDE_PACKAGE_DATA = True
 PACKAGE_DATA_FILES = [ ]
+PACKAGE_CLASSIFIERS = ['Programming Language :: Python :: 2.7',
+                       'Programming Language :: Python :: 3']
 
 with open(readme_filename) as f:
     PACKAGE_LONG_DESCRIPTION = f.read()
@@ -41,5 +43,6 @@ setup(
     install_requires=PACKAGE_INSTALL_REQUIRES,
     include_package_data=PACKAGE_INCLUDE_PACKAGE_DATA,
     data_files=PACKAGE_DATA_FILES,
-    entry_points={}
+    entry_points={},
+    classifiers=PACKAGE_CLASSIFIERS
 )

--- a/xplenty/xplenty_api.py
+++ b/xplenty/xplenty_api.py
@@ -52,7 +52,7 @@ def to_python(obj,
             in_date = in_dict.get(in_key)
             try:
                 out_date = parse_datetime(in_date)
-            except Exception, e:
+            except Exception as e:
                 #raise e
                 out_date = None
 
@@ -266,7 +266,7 @@ class XplentyClient(object):
 
         try:
             resp = urllib2.urlopen(request)
-        except urllib2.HTTPError, error:
+        except urllib2.HTTPError as error:
             raise XplentyAPIException(error)
 
         return json.loads(resp.read())
@@ -281,7 +281,7 @@ class XplentyClient(object):
 
         try:
             resp = urllib2.urlopen(request)
-        except urllib2.HTTPError, error:
+        except urllib2.HTTPError as error:
             raise XplentyAPIException(error)
 
         return json.loads(resp.read())
@@ -294,7 +294,7 @@ class XplentyClient(object):
 
         try:
             resp = urllib2.urlopen(request)
-        except urllib2.HTTPError, error:
+        except urllib2.HTTPError as error:
             raise XplentyAPIException(error)
 
         return json.loads(resp.read())

--- a/xplenty/xplenty_api.py
+++ b/xplenty/xplenty_api.py
@@ -119,7 +119,7 @@ class BaseModel(object):
             setattr(self, attr, None)
 
     def _keys(self):
-        return self._strs + self._ints + self._dates + self._bools + self._map.keys()
+        return self._strs + self._ints + self._dates + self._bools + list(self._map.keys())
 
     @property
     def _id(self):

--- a/xplenty/xplenty_api.py
+++ b/xplenty/xplenty_api.py
@@ -373,11 +373,11 @@ class XplentyClient(object):
         # We use job_id instead of package_id since that's how it is accepted on Xplenty's side
         job_info["job[job_id]"]= package_id
 
-        for k, v in vars.iteritems():
+        for k, v in vars.items():
             new_key = "job[variables][%s]"%(k)
             job_info[new_key]= v
 
-        for k, v in dynamic_vars.iteritems():
+        for k, v in dynamic_vars.items():
             new_key = "job[dynamic_variables][%s]"%(k)
             job_info[new_key]= v
 

--- a/xplenty/xplenty_api.py
+++ b/xplenty/xplenty_api.py
@@ -2,10 +2,14 @@
 import base64
 import json
 import logging
-import urllib
-import urllib2
-from urlparse import urljoin
-
+try:
+    from urllib.parse import urlencode, urljoin
+    from urllib.request import urlopen, Request
+    from urllib.error import HTTPError
+except ImportError:
+    from urllib import urlencode
+    from urllib2 import urlopen, Request, HTTPError
+    from urlparse import urljoin
 from dateutil.parser import parse as parse_datetime
 
 from .exceptions import XplentyAPIException
@@ -233,19 +237,19 @@ class Schedule(BaseModel):
         return "<Schedule '{0}'>".format(self.name)
 
 
-class RequestWithMethod(urllib2.Request):
+class RequestWithMethod(Request):
     """Workaround for using DELETE with urllib2"""
     def __init__(self, url, method, data=None, headers={},\
         origin_req_host=None, unverifiable=False):
         self._method = method
-        urllib2.Request.__init__(self, url, data, headers,\
+        Request.__init__(self, url, data, headers,\
                  origin_req_host, unverifiable)
 
     def get_method(self):
         if self._method:
             return self._method
         else:
-            return urllib2.Request.get_method(self)
+            return Request.get_method(self)
 
 
 class XplentyClient(object):
@@ -260,28 +264,28 @@ class XplentyClient(object):
 
     def get(self,url):
         logger.debug("GET %s", url)
-        request = urllib2.Request(url,headers=HEADERS)
+        request = Request(url,headers=HEADERS)
         base64string = base64.encodestring('%s' % (self.api_key)).replace('\n', '')
         request.add_header("Authorization", "Basic %s" % base64string)
 
         try:
-            resp = urllib2.urlopen(request)
-        except urllib2.HTTPError as error:
+            resp = urlopen(request)
+        except HTTPError as error:
             raise XplentyAPIException(error)
 
         return json.loads(resp.read())
 
     def post(self, url, data_dict={}):
-        encoded_data = urllib.urlencode(data_dict)
+        encoded_data = urlencode(data_dict)
         logger.debug("POST %s, data %s", url, encoded_data)
 
-        request = urllib2.Request(url, data=encoded_data, headers=HEADERS)
+        request = Request(url, data=encoded_data, headers=HEADERS)
         base64string = base64.encodestring('%s' % (self.api_key)).replace('\n', '')
         request.add_header("Authorization", "Basic %s" % base64string)
 
         try:
-            resp = urllib2.urlopen(request)
-        except urllib2.HTTPError as error:
+            resp = urlopen(request)
+        except HTTPError as error:
             raise XplentyAPIException(error)
 
         return json.loads(resp.read())
@@ -293,8 +297,8 @@ class XplentyClient(object):
         request.add_header("Authorization", "Basic %s" % base64string)
 
         try:
-            resp = urllib2.urlopen(request)
-        except urllib2.HTTPError as error:
+            resp = urlopen(request)
+        except HTTPError as error:
             raise XplentyAPIException(error)
 
         return json.loads(resp.read())


### PR DESCRIPTION
I used [`2to3`](http://python3porting.com/2to3.html) to identify code that needed to be modified to allow this library to run with python 3. I inspected the suggested changes and ensured that the modifications made still worked in python 2. Many of the changes are backward compatible with python 2, but changes to `urllib`/`urllib2` required more nuanced changes (see "Changes" section below).

Additionally, I've added classifiers in `setup.py` to indicate to clients that this library runs in both python 2.7 and python 3.

## Testing

Unfortunately `xplenty.py` has no tests, so validating these changes in both versions of python was not straightforward. I have a client library that uses `xplenty.py` that has several tests. I ran those tests using python 2 and 3 and all tests passed. I verified that if `xplenty.py` was not python 3 compatible, then the tests for my client in python 3 would fail.

#### Python 2 test output

```
=============================================================================== test session starts ===============================================================================
platform darwin -- Python 2.7.13, pytest-3.4.0, py-1.5.2, pluggy-0.6.0
rootdir: /Users/tomcollier/dev/al/airflow_xplenty, inifile:
plugins: celery-4.1.0
collected 8 items                                                                                                                                                                 

tests/airflow_xplenty/test_client_factory.py ...                                                                                                                            [ 37%]
tests/airflow_xplenty/operators/test_xplenty_find_or_start_cluster_operator.py .....                                                                                        [100%]

============================================================================ 8 passed in 1.13 seconds =============================================================================
```

#### Python 3 test output

```
=============================================================================== test session starts ===============================================================================
platform darwin -- Python 3.6.5, pytest-3.2.2, py-1.4.34, pluggy-0.4.0
rootdir: /Users/tomcollier/dev/al/airflow_xplenty, inifile:
plugins: celery-4.1.0
collected 8 items                                                                                                                                                                  

tests/airflow_xplenty/test_client_factory.py ...
tests/airflow_xplenty/operators/test_xplenty_find_or_start_cluster_operator.py .....

============================================================================ 8 passed in 2.02 seconds =============================================================================
```

## Changes

### Update exception catching to python 3 format
Python 3 no longer supports [separating the exception class and variable name with a comma.](http://python-future.org/compatible_idioms.html#catching-exceptions)

#### Python 2 only
```python
try:
    ...
except ValueError, e:
    ...
```

#### Python 2 and 3
```python
try:
    ...
except ValueError as e:
    ...
```

### Cast iterable object to list before concatenating
The return type from `.keys()` [changed from a list in python 2 to an iterable object](http://btmiller.com/2015/04/13/get-list-of-keys-from-dictionary-in-python-2-and-3.html), which cannot be concatenated with a list.

#### Python 2
```python
my_list = ['a']
my_dict = {'b': True}
my_list + my_dict.keys()
# => ['a', 'b']
```

#### Python 3
```python
my_list = ['a']
my_dict = {'b': True}
my_list + my_dict.keys()
# Traceback (most recent call last):
#   File "<stdin>", line 1, in <module>
# TypeError: can only concatenate list (not "dict_keys") to list
my_list + list(my_dict.keys())
# => ['a', 'b']
```

### Use items() instead of iteritems() for dictionary
The dictionary function `.iteritems()` [has been removed in python 3](http://python-future.org/compatible_idioms.html#iterating-through-dict-keys-values-items). While the return type of `.items()` has changed, it can still be used the same in python 3 as in python 2 in many cases.

#### Python 3
```python
my_dict =  {'a': 1, 'b': 2}
my_dict.iteritems()
# Traceback (most recent call last):
#   File "<stdin>", line 1, in <module>
# AttributeError: 'dict' object has no attribute 'iteritems'
```

#### Python 2 or 3
```python
my_dict = {'a': 1, 'b': 2}
for (k, v) in my_dict.items():
    print("{}={}".format(k, v))
# a=1
# b=2
```

### Changes to urllib (and related) modules
Functions and modules in `urllib`, `urllib2`, and `urlparse` [have all been moved into `urllib` and oftentimes in different places](http://python-future.org/compatible_idioms.html#urllib-module). The strategy to use `urllib` with the same code for python 2 and 3 is to attempt to import assuming we're in python 3. Then if we catch an `ImportError`, attempt the import again assuming python 2.

#### Python 2 or 3
```python
try:
    from urllib.request import Request
except ImportError:
    from urllib2 import Request
```