### PR TITLE
Use proper encoding/decoding for python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def get_project_path(*args):
     return os.path.abspath(os.path.join(this_dir, *args))
 
 PACKAGE_NAME = 'xplenty'
-PACKAGE_VERSION = '1.2.0'
+PACKAGE_VERSION = '1.2.1'
 PACKAGE_AUTHOR = 'Xplenty'
 PACKAGE_AUTHOR_EMAIL = 'opensource@xplenty.com'
 PACKAGE_URL = 'https://github.com/xplenty/xplenty.py'

--- a/xplenty/xplenty_api.py
+++ b/xplenty/xplenty_api.py
@@ -265,7 +265,8 @@ class XplentyClient(object):
     def get(self,url):
         logger.debug("GET %s", url)
         request = Request(url,headers=HEADERS)
-        base64string = base64.encodestring('%s' % (self.api_key)).replace('\n', '')
+        bytestring = self.api_key.encode()
+        base64string = base64.encodestring(bytestring).decode().replace('\n', '')
         request.add_header("Authorization", "Basic %s" % base64string)
 
         try:
@@ -276,11 +277,12 @@ class XplentyClient(object):
         return json.loads(resp.read())
 
     def post(self, url, data_dict={}):
-        encoded_data = urlencode(data_dict)
+        encoded_data = urlencode(data_dict).encode()
         logger.debug("POST %s, data %s", url, encoded_data)
 
         request = Request(url, data=encoded_data, headers=HEADERS)
-        base64string = base64.encodestring('%s' % (self.api_key)).replace('\n', '')
+        bytestring = self.api_key.encode()
+        base64string = base64.encodestring(bytestring).decode().replace('\n', '')
         request.add_header("Authorization", "Basic %s" % base64string)
 
         try:
@@ -293,7 +295,8 @@ class XplentyClient(object):
     def delete(self, url):
         logger.debug("DELETE %s", url)
         request = RequestWithMethod(url, 'DELETE', headers=HEADERS)
-        base64string = base64.encodestring('%s' % (self.api_key)).replace('\n', '')
+        bytestring = self.api_key.encode()
+        base64string = base64.encodestring(bytestring).decode().replace('\n', '')
         request.add_header("Authorization", "Basic %s" % base64string)
 
         try:


### PR DESCRIPTION
Base 64 encoding changed from python 2 to python 3. The old code was raising an error in python 2

```python
TypeError: expected bytes-like object, not str
```

The new code works in both python 2 and 3.

I have updated the version one patch level.